### PR TITLE
Fix usage of positional argument after named arguments

### DIFF
--- a/src/main/scala/com/greenfossil/data/mapping/ProductMapping.scala
+++ b/src/main/scala/com/greenfossil/data/mapping/ProductMapping.scala
@@ -197,7 +197,7 @@ case class ProductMapping[A](tpe: String,
       [A] => (a: A) => a match
         case m: Mapping[?] => m.filterErrors(predicate)
     )
-    copy(errors = errors.filter(predicate), newMappings)
+    copy(errors = errors.filter(predicate), mappings = newMappings)
 
 
   override def noOfFields: Int =


### PR DESCRIPTION
Scala 3.4.x fixes a bug, allowing to use positional arguments after named ones. These could have been misleading to users. The fix lead to failures of 3 Open Community Projects, one of them is this one. [Link to build logs](https://github.com/VirtusLab/community-build3/actions/runs/6593484431/job/17917351691) 

Merging this PR and applying the fix would allow for further testing this project against latest versions of Scala 3